### PR TITLE
Fixed expectedOutputAmount value in Test

### DIFF
--- a/test/PancakePair.spec.ts
+++ b/test/PancakePair.spec.ts
@@ -246,7 +246,7 @@ describe('PancakePair', () => {
     await addLiquidity(token0Amount, token1Amount)
 
     const swapAmount = expandTo18Decimals(1)
-    const expectedOutputAmount = bigNumberify('996006981039903216')
+    const expectedOutputAmount = bigNumberify('997004989020957084')
     await token1.transfer(pair.address, swapAmount)
     await pair.swap(expectedOutputAmount, 0, wallet.address, '0x', overrides)
 
@@ -264,7 +264,7 @@ describe('PancakePair', () => {
     await addLiquidity(token0Amount, token1Amount)
 
     const swapAmount = expandTo18Decimals(1)
-    const expectedOutputAmount = bigNumberify('996006981039903216')
+    const expectedOutputAmount = bigNumberify('997004989020957084')
     await token1.transfer(pair.address, swapAmount)
     await pair.swap(expectedOutputAmount, 0, wallet.address, '0x', overrides)
 


### PR DESCRIPTION
Previous value is being calculated based on the 0.3% swap fees model , instead should be done based on the Pancake V1 (0.2% fees) 